### PR TITLE
relax numpy requirement, remove Cython req from setup.py

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -6,7 +6,7 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy >=1.10
+    - numpy >=1.10,<2.0
     - cython >=0.23
     - msinttypes r26  # [win]
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import versioneer
 
 cython_modules = ['cypico/pico.pyx']
 
-requirements = ['numpy>=1.10,<=1.11', 'Cython>=0.23,<=0.24']
+requirements = ['numpy>=1.10,<2.0']
 
 setup(name='cypico',
       version=versioneer.get_version(),


### PR DESCRIPTION
Currently the `setup.py` dep on numpy is very strict - relax it to be in line with menpo.